### PR TITLE
Geoblock works.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,12 +134,12 @@ class CatalogController < ApplicationController
   #  def index
   #  end
 
-  def is_geoblocked?
+  def geoblocked?
     country_code = GeoIPCountry.instance.country_code(request.remote_ip)
     @pbcore.blocked_country_codes.include?(country_code)
   end
-  helper_method :is_geoblocked?
-  
+  helper_method :geoblocked?
+
   def show
     # TODO: do we need more of the behavior from Blacklight::Catalog?
     @response, @document = fetch(params['id'])

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,4 +1,5 @@
 require_relative '../../lib/open_vault'
+require_relative '../../lib/geo_i_p_country'
 
 class CatalogController < ApplicationController
   include Blacklight::Catalog
@@ -133,6 +134,12 @@ class CatalogController < ApplicationController
   #  def index
   #  end
 
+  def is_geoblocked?
+    country_code = GeoIPCountry.instance.country_code(request.remote_ip)
+    @pbcore.blocked_country_codes.include?(country_code)
+  end
+  helper_method :is_geoblocked?
+  
   def show
     # TODO: do we need more of the behavior from Blacklight::Catalog?
     @response, @document = fetch(params['id'])

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -6,18 +6,25 @@
       <%= tag('img', src: @pbcore.thumbnail_src) %>
       <br/>
     <% end %>
-    <%= content_tag(@pbcore.video? ? 'video' : 'audio', 
-                  controls: true, id: 'player-media',
-                  oncontextmenu: 'return false;', 
-                  class: 'col-lg-4 col-md-5 col-sm-6 col-xs-12',
-                  poster: @pbcore.thumbnail_src) do %>
-      <% @pbcore.proxy_srcs.each do |src| %>
-        <%= tag('source', src: src, type: @pbcore.video? ? 'video/mp4' : 'audio/mp3') %>
+    <% if is_geoblocked? %>
+      <div class="col-lg-4 col-md-5 col-sm-6 col-xs-12">
+        <%# Blacklight alert classes seemed too colorful. %>
+        <strong>Note:</strong> This content is not available in your region.</p>
+      </div>
+    <% else %>
+      <%= content_tag(@pbcore.video? ? 'video' : 'audio', 
+                    controls: true, id: 'player-media',
+                    oncontextmenu: 'return false;', 
+                    class: 'col-lg-4 col-md-5 col-sm-6 col-xs-12',
+                    poster: @pbcore.thumbnail_src) do %>
+        <% @pbcore.proxy_srcs.each do |src| %>
+          <%= tag('source', src: src, type: @pbcore.video? ? 'video/mp4' : 'audio/mp3') %>
+        <% end %>
+
+        <!-- We have transcripts, but not SRT caption files:
+          <track kind="captions" src="..."/>
+        -->
       <% end %>
-      
-      <!-- We have transcripts, but not SRT caption files:
-        <track kind="captions" src="..."/>
-      -->
     <% end %>
   <% end %>
   <% if @pbcore.transcript_src %>

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -6,7 +6,7 @@
       <%= tag('img', src: @pbcore.thumbnail_src) %>
       <br/>
     <% end %>
-    <% if is_geoblocked? %>
+    <% if geoblocked? %>
       <div class="col-lg-4 col-md-5 col-sm-6 col-xs-12">
         <%# Blacklight alert classes seemed too colorful. %>
         <strong>Note:</strong> This content is not available in your region.

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -9,7 +9,7 @@
     <% if is_geoblocked? %>
       <div class="col-lg-4 col-md-5 col-sm-6 col-xs-12">
         <%# Blacklight alert classes seemed too colorful. %>
-        <strong>Note:</strong> This content is not available in your region.</p>
+        <strong>Note:</strong> This content is not available in your region.
       </div>
     <% else %>
       <%= content_tag(@pbcore.video? ? 'video' : 'audio', 

--- a/spec/fixtures/pbcore/good-all-fields.xml
+++ b/spec/fixtures/pbcore/good-all-fields.xml
@@ -57,7 +57,7 @@
   <pbcoreAnnotation annotationType="Outside URL">http://americanarchive.org/</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="Playlist Group"/>
   <pbcoreAnnotation annotationType="Playlist Order"/>
-  <pbcoreAnnotation annotationType="Geoblock">GB</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Geoblock">--</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="Password">YES</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="Digitized">YES</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="Thumbnail">YES</pbcoreAnnotation>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -118,7 +118,7 @@ describe 'Validated and plain PBCore' do
         genres: ['GENRE-1', 'GENRE-2'],
         topics: ['TOPIC-1', 'TOPIC-2'],
         locations: ['LOCATION-1', 'LOCATION-2'],
-        blocked_country_codes: ['GB'],
+        blocked_country_codes: ['--'],
         password_required?: true,
         special_collections: ['war_peace'],
         special_collection_tags: ['war_interview'],


### PR DESCRIPTION
@afred? "--" in the fixture so that when you ingest it WGBH (which has never geocoded correctly) will be geoblocked on the sample record. Here's what it looks like: nothing fancy.

<img width="965" alt="screen shot 2016-01-29 at 2 16 18 pm" src="https://cloud.githubusercontent.com/assets/730388/12685622/76975eb6-c693-11e5-8ca4-e8ad83ae4f55.png">
