### PR TITLE
More items in each facet column

### DIFF
--- a/app/views/catalog/_facet_limit.html.erb
+++ b/app/views/catalog/_facet_limit.html.erb
@@ -1,5 +1,5 @@
 <% items = facet_paginator(facet_field, display_facet).items %>
-<% cols = 1 + items.count / 8 %>
+<% cols = 1 + items.count / 15 %>
 <% items.in_groups(cols, false) do |group| %>
   <ul class="facet-values list-unstyled">
     <%# OV: Pass items rather than just paginator. %>


### PR DESCRIPTION
@afred? Fix #137.

Might also bump up the "width: 500px", but that causes other problems. More than 15 and we  likely exceed screen height. (Could already be too many?) Might also make font smaller? Tried, but couldn't get it to hyphenate any less.

<img width="523" alt="screen shot 2016-02-05 at 11 26 11 am" src="https://cloud.githubusercontent.com/assets/730388/12852141/86a232f0-cbfb-11e5-9336-5644d470dbc5.png">
