### PR TITLE
Copy and paste css to preserve aspect ratio.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -30,3 +30,4 @@
 @import "locals/catalog-show";
 @import "locals/series-index";
 @import "locals/plain";
+@import "locals/aspect-ratio";

--- a/app/assets/stylesheets/locals/aspect-ratio.css.scss
+++ b/app/assets/stylesheets/locals/aspect-ratio.css.scss
@@ -1,0 +1,20 @@
+// Inspired by https://css-tricks.com/snippets/sass/maintain-aspect-ratio-mixin/
+
+.aspect-ratio {
+  $ratio: 362 / 229;
+  position: relative;
+  &:before {
+    display: block;
+    content: "";
+    width: 100%;
+    padding-top: 100% / $ratio;
+  }
+  > .content {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow: hidden; // Not in example, but seems necessary to me.
+  }
+}

--- a/app/assets/stylesheets/locals/aspect-ratio.css.scss
+++ b/app/assets/stylesheets/locals/aspect-ratio.css.scss
@@ -1,20 +1,47 @@
-// Inspired by https://css-tricks.com/snippets/sass/maintain-aspect-ratio-mixin/
+// Inspired by https://css-tricks.com/snippets/sass/maintain-aspect-ratio-
+// mixin/ but removed use of pseudo element because I don't think it is needed
+// to get the desired effect. See below for examples of usage within markup.
 
-.aspect-ratio {
-  $ratio: 362 / 229;
+@mixin aspect-ratio($width, $height) {
   position: relative;
-  &:before {
-    display: block;
-    content: "";
-    width: 100%;
-    padding-top: 100% / $ratio;
-  }
-  > .content {
+
+  // When padding is a %, it's calculated as a % of the width of the
+  // containing box. This is how the ratio is maintained.
+  padding-bottom: 100% / ($width / $height);
+
+  // Hide anything outside of the .content box. This can be parameterized in
+  // the mixin if we need to turn it on/off.
+  overflow: hidden;
+
+  // For the contained content, we have an immediate child container that
+  // stretches to it's parent. If you want style the *inside* of the content
+  // within the aspec-ratio container, then apply those styles to the .content
+  // element.
+  > .aspect-ratio-content {
+    // stretch the .content element to it's parent with positioning.
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    overflow: hidden; // Not in example, but seems necessary to me.
   }
 }
+
+// Implement a 16x9 class
+.aspect-ratio-16x9 {
+  @include aspect-ratio(16, 9);
+}
+
+// Implement a 4x3 class
+.aspect-ratio-4x3 {
+  @include aspect-ratio(4, 3);
+}
+
+
+// Examples of usage within markup:
+// 
+// <div class="aspect-ratio-16x9">
+//   <div class="aspect-ratio-content">
+//     Content in here will maintain a 16:9 aspect ratio.
+//   </div>
+// </div>

--- a/app/views/shared/_document.html.erb
+++ b/app/views/shared/_document.html.erb
@@ -1,5 +1,9 @@
 <a href="/catalog/<%= document.id %>">
-  <img src="<%= document[:thumbnail_src] %>">
+  <div class="aspect-ratio">
+    <div class="content">
+      <img src="<%= document[:thumbnail_src] %>">
+    </div>
+  </div>
   <div class="info">
     <%= document[:title] %>
   </div>

--- a/app/views/shared/_document.html.erb
+++ b/app/views/shared/_document.html.erb
@@ -1,6 +1,6 @@
 <a href="/catalog/<%= document.id %>">
-  <div class="aspect-ratio">
-    <div class="content">
+  <div class="aspect-ratio-16x9">
+    <div class="aspect-ratio-content">
       <img src="<%= document[:thumbnail_src] %>">
     </div>
   </div>


### PR DESCRIPTION
@afred. Alternative to #135. Works, but...
- `overflow` wasn't in the example I copied, but it seems necessary here?
- I don't really understand what it's doing.

Maybe if it makes sense to you, add a comment and/or a diagram in the code to explain it to future generations?