### PR TITLE
Ingest nil errors

### DIFF
--- a/scripts/lib/pb_core_ingester.rb
+++ b/scripts/lib/pb_core_ingester.rb
@@ -46,7 +46,8 @@ class PBCoreIngester
       Zip::File.open(path) do |zip_file|
         zip_file.each do |entry|
           begin
-            ingest_xml_no_commit(entry.get_input_stream.read)
+            ingest_xml_no_commit(entry.get_input_stream.read) ||
+              $LOG.warn("No match. Skipping #{path} :: #{entry.name} ")
             commit unless is_batch_commit
           rescue => e
             record_error(e, "#{path} :: #{entry.name}")
@@ -55,7 +56,8 @@ class PBCoreIngester
       end
     rescue Zip::Error
       begin
-        ingest_xml_no_commit(File.read(path))
+        ingest_xml_no_commit(File.read(path)) ||
+          $LOG.warn("No match. Skipping #{path} :: #{entry.name} ")
       rescue => e
         record_error(e, path)
       end
@@ -89,6 +91,8 @@ class PBCoreIngester
       end
       $LOG.info("Updated solr record #{pbcore.id}")
       @success_count += 1
+    else
+      false # Not strictly necessary, but a good reminder that the return value is consumed.
     end
   end
 

--- a/scripts/lib/pb_core_ingester.rb
+++ b/scripts/lib/pb_core_ingester.rb
@@ -48,7 +48,6 @@ class PBCoreIngester
           begin
             ingest_xml_no_commit(entry.get_input_stream.read)
             commit unless is_batch_commit
-            @success_count += 1
           rescue => e
             record_error(e, "#{path} :: #{entry.name}")
           end
@@ -57,7 +56,6 @@ class PBCoreIngester
     rescue Zip::Error
       begin
         ingest_xml_no_commit(File.read(path))
-        @success_count += 1
       rescue => e
         record_error(e, path)
       end
@@ -90,11 +88,8 @@ class PBCoreIngester
         raise SolrError.new(e)
       end
       $LOG.info("Updated solr record #{pbcore.id}")
-    else
-      $LOG.info("Skip solr record #{pbcore.id}: does not match #{@re}")
+      @success_count += 1
     end
-
-    pbcore
   end
 
   class ChainedError < StandardError


### PR DESCRIPTION
@afred? Fix #157. 

(AAPB does some solid testing of the output of the tests, and we could do something like that here... except that the way it works by capturing all output makes the tests themselves a pain to debug because it captures the pry output itself. Also, the ingest machinery here is a lot less complicated, so I'm more comfortable with the tests essentially being our usage of it.)