### PR TITLE
Fixes videos playback for Chrome

### DIFF
--- a/app/assets/javascripts/player.js
+++ b/app/assets/javascripts/player.js
@@ -31,10 +31,7 @@ $(function(){
         var $player = $('#player-media');
         
         function set_user_scroll(state) {
-            console.log('scroll was', is_user_scroll());
             $player.data('user-scroll', state);
-            console.log('scroll should be', state);
-            console.log('scroll is', is_user_scroll());
         }
         
         function is_user_scroll() {

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -104,7 +104,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
   def extensions
     case media_type
     when VIDEO
-      %w(mp4 webm)
+      %w(webm mp4)
     when AUDIO
       ['mp3']
     when IMAGE

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -101,7 +101,7 @@ describe 'Validated and plain PBCore' do
         asset_description: 'ASSET-DESCRIPTION',
         id: 'A_00000000_MOCK',
         thumbnail_src: "#{base}/asset_thumbnails/#{id}.jpg",
-        proxy_srcs: %w(mp4 webm).map { |ext| "#{base}/asset_proxies/#{id}.#{ext}" },
+        proxy_srcs: %w(webm mp4).map { |ext| "#{base}/asset_proxies/#{id}.#{ext}" },
         rights_summary: 'RIGHTS-SUMMARY',
         contributors: [
           PBCoreNameRole.new('contributor', 'CONTRIBUTOR-NAME-1', 'CONTRIBUTOR-ROLE-1'),
@@ -126,7 +126,7 @@ describe 'Validated and plain PBCore' do
         scholar_exhibits: ['needlework'],
         aapb_url: 'http://americanarchive.org/',
         boston_tv_news_url: nil,
-        extensions: %w(mp4 webm),
+        extensions: %w(webm mp4),
         outside_url: 'http://americanarchive.org/',
         transcript_src: 'https://s3.amazonaws.com/openvault.wgbh.org/catalog/asset_transcripts/A_00000000_MOCK.xml' }
       assertions[:to_solr] = assertions.slice(


### PR DESCRIPTION
Requires putting webm before mp4.
Also removes console.log in transcript scrolling javascript.