### PR TITLE
Respect double line breaks in source data. 

### DIFF
--- a/app/views/catalog/_pbcore_field.html.erb
+++ b/app/views/catalog/_pbcore_field.html.erb
@@ -13,7 +13,7 @@
       elsif search_link
         link_to(value, "/catalog?q=#{CGI.escape(value.respond_to?(:name) ? value.name : value)}")
       else
-        value
+        value.split(/[\n\r]\s*[\n\r]/).map { |v| content_tag(:p,html_escape(v.strip)) }.join.html_safe
       end
     %></dd>
   <% end %>

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -7,69 +7,74 @@ describe 'Catalog' do
     PBCoreIngester.load_fixtures
   end
 
-  it 'loads the index page' do
-    visit '/catalog'
-    expect(page.status_code).to eq(200)
-    expect_fuzzy_xml
+  describe '#index' do
+    it 'loads the index page' do
+      visit '/catalog'
+      expect(page.status_code).to eq(200)
+      expect_fuzzy_xml
+    end
+
+    it 'redirects missing access' do
+      visit '/catalog?q='
+      expect(page.status_code).to eq(200)
+      expect(URI.parse(current_url).query).to eq('f[access][]=Available+Online&q=')
+    end
+
+    it 'redirects missing everything' do
+      visit '/catalog?'
+      expect(page.status_code).to eq(200)
+      expect(URI.parse(current_url).query).to eq('f[access][]=Available+Online')
+    end
+
+    it 'has a helpful no-results' do
+      visit '/catalog?q=asdfasfasdf'
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content 'Consider using other search terms, removing filters, or searching all records, not just those with media.'
+      expect_fuzzy_xml
+    end
+
+    it 'also has an unhelpful no-results' do
+      visit '/catalog?q=asdfasfasdf&f[access][]=All+Records'
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content 'Consider using other search terms or removing filters.'
+      expect_fuzzy_xml
+    end
+
+    it 'sorts by title ascending, ignoring articles' do
+      visit '/catalog?f[access][]=All+Records&q=sort&sort=title+asc'
+      expect(page.status_code).to eq(200)
+      expect_fuzzy_xml
+      expect(page.all('.info').map(&:text)).to eq([
+        '"The" removed: sort 1',
+        '"An" REMOVED: SORT 2',
+        '"A" removed: sort 3'
+      ])
+    end
+
+    it 'sorts by title descending, ignoring articles' do
+      visit '/catalog?f[access][]=All+Records&q=sort&sort=title+desc'
+      expect(page.status_code).to eq(200)
+      expect_fuzzy_xml
+      expect(page.all('.info').map(&:text)).to eq([
+        '"A" removed: sort 3',
+        '"An" REMOVED: SORT 2',
+        '"The" removed: sort 1'
+      ])
+    end
   end
 
-  it 'redirects missing access' do
-    visit '/catalog?q='
-    expect(page.status_code).to eq(200)
-    expect(URI.parse(current_url).query).to eq('f[access][]=Available+Online&q=')
-  end
+  describe '#show' do
+    it 'loads a full details page' do
+      visit '/catalog/A_00000000_MOCK'
+      expect(page.status_code).to eq(200)
+      expect_fuzzy_xml
+    end
 
-  it 'redirects missing everything' do
-    visit '/catalog?'
-    expect(page.status_code).to eq(200)
-    expect(URI.parse(current_url).query).to eq('f[access][]=Available+Online')
-  end
-
-  it 'has a helpful no-results' do
-    visit '/catalog?q=asdfasfasdf'
-    expect(page.status_code).to eq(200)
-    expect(page).to have_content 'Consider using other search terms, removing filters, or searching all records, not just those with media.'
-    expect_fuzzy_xml
-  end
-
-  it 'also has an unhelpful no-results' do
-    visit '/catalog?q=asdfasfasdf&f[access][]=All+Records'
-    expect(page.status_code).to eq(200)
-    expect(page).to have_content 'Consider using other search terms or removing filters.'
-    expect_fuzzy_xml
-  end
-
-  it 'loads a full details page' do
-    visit '/catalog/A_00000000_MOCK'
-    expect(page.status_code).to eq(200)
-    expect_fuzzy_xml
-  end
-
-  it 'loads a minimal details page' do
-    visit '/catalog/A_00B0C50853C64A71935737EF7A4DA66C'
-    expect(page.status_code).to eq(200)
-    expect_fuzzy_xml
-  end
-
-  it 'sorts by title ascending, ignoring articles' do
-    visit '/catalog?f[access][]=All+Records&q=sort&sort=title+asc'
-    expect(page.status_code).to eq(200)
-    expect_fuzzy_xml
-    expect(page.all('.info').map(&:text)).to eq([
-      '"The" removed: sort 1',
-      '"An" REMOVED: SORT 2',
-      '"A" removed: sort 3'
-    ])
-  end
-
-  it 'sorts by title descending, ignoring articles' do
-    visit '/catalog?f[access][]=All+Records&q=sort&sort=title+desc'
-    expect(page.status_code).to eq(200)
-    expect_fuzzy_xml
-    expect(page.all('.info').map(&:text)).to eq([
-      '"A" removed: sort 3',
-      '"An" REMOVED: SORT 2',
-      '"The" removed: sort 1'
-    ])
+    it 'loads a minimal details page' do
+      visit '/catalog/A_00B0C50853C64A71935737EF7A4DA66C'
+      expect(page.status_code).to eq(200)
+      expect_fuzzy_xml
+      expect(page.html).to match(/<p>Line breaks\s+do not matter, but<\/p><p>empty lines do\.<\/p>/)
+    end
   end
 end

--- a/spec/fixtures/pbcore/good-required-fields.xml
+++ b/spec/fixtures/pbcore/good-required-fields.xml
@@ -3,7 +3,12 @@
   <pbcoreAssetType>Original footage</pbcoreAssetType>
   <pbcoreIdentifier source="Open Vault UID">A_00B0C50853C64A71935737EF7A4DA66C</pbcoreIdentifier>
   <pbcoreTitle titleType="Series">(at least one title required by schema.)</pbcoreTitle>
-  <pbcoreDescription descriptionType="Series Description">(at least one description required by schema.)</pbcoreDescription>
+  <pbcoreDescription descriptionType="Series Description">
+      Line breaks
+      do not matter, but
+      
+      empty lines do.
+  </pbcoreDescription>
   <pbcoreAnnotation annotationType="Media Type">Audio</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="Digitized">YES</pbcoreAnnotation>
 </pbcoreDescriptionDocument>


### PR DESCRIPTION
Towards #176... but keep open till source data is correct.
@afred?

<img width="360" alt="screen shot 2016-02-15 at 11 05 31 am" src="https://cloud.githubusercontent.com/assets/730388/13053758/305da358-d3d4-11e5-90a8-0089c449f1fc.png">
