### PR TITLE
Iframe for embedding in articles. Fix #245.

### DIFF
--- a/app/assets/stylesheets/locals/collections-exhibits.css.scss
+++ b/app/assets/stylesheets/locals/collections-exhibits.css.scss
@@ -89,9 +89,12 @@
         
         iframe {
             // (For embeds)
-            width: 380px;
-            height: 260px;
+            // If this were really wide, we might want media queries,
+            // but seems like enough for now.
+            width: 700px;
+            height: 300px;
             border: none;
+            background: $pale-grey;
         }
     }
 }

--- a/app/views/embed/show.html.erb
+++ b/app/views/embed/show.html.erb
@@ -4,9 +4,13 @@
     <%= render partial: 'catalog/player' %>
   </div>
   <h2>
-    <a href="/catalog/<%= @pbcore.id %>"><%= @pbcore.asset_title %></a>
+    <a href="/catalog/<%= @pbcore.id %>"><%=
+      @pbcore.asset_title || @pbcore.program_title || @pbcore.series_title
+    %></a>
   </h2>
   <p>
-    <%= @pbcore.asset_description.html_safe %>
+    <%= (
+      @pbcore.asset_description || @pbcore.program_description || @pbcore.series_description
+    ).html_safe %>
   </p>
 </div>

--- a/app/views/embed/show.html.erb
+++ b/app/views/embed/show.html.erb
@@ -1,1 +1,12 @@
-<%= render partial: 'catalog/player' %>
+<%# Inline styles for now: we might make them URL params at some point? %>
+<div>
+  <div style="width: 380px; float: left;">
+    <%= render partial: 'catalog/player' %>
+  </div>
+  <h2>
+    <a href="/catalog/<%= @pbcore.id %>"><%= @pbcore.asset_title %></a>
+  </h2>
+  <p>
+    <%= @pbcore.asset_description.html_safe %>
+  </p>
+</div>


### PR DESCRIPTION
@afred:
- I think we might have broached the idea of making this configurable, either by extension or URL params, but for now there's precisely one use case, and I don't want to prematurely generalize.
- There's extra room, so I'm including the description... but if other folks think it's a distraction rather than a help, we can certainly get rid of it.
- Title: I'm just using the `asset_title`, since I presume the article will provide context. If need be, we can revisit, but for this one example, this seemed like the best choice.

Fix #245 

<img width="899" alt="screen shot 2016-02-19 at 10 47 12 am" src="https://cloud.githubusercontent.com/assets/730388/13180381/3660fa8c-d6f6-11e5-838a-e64497c4dfcb.png">
