### PR TITLE
Modal for digitization. Towards #248.

### DIFF
--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -18,14 +18,9 @@
     <% if geoblocked? %>
       <strong>Note:</strong> This content is not available in your region.
     <% elsif !@pbcore.digitized? %>
-      This item has not been digitized. 
-      If you are interested in sponsoring digitization, 
-      <a href="mailto:openvault@wgbh.org?<%=
-        {
-          subject: 'Digitization request',
-          body: 'I am interested in digitizing http://openvault.wgbh.org/catalog/' + @pbcore.id
-        }.to_query
-      %>">contact us</a>.
+      Undigitized item: <span class="btn btn-primary btn-sm" 
+                              onclick="$('#request-modal').modal('show');">
+                            Request Digitization</span>
     <% elsif !@pbcore.proxy_srcs.empty? %>
       <%= content_tag(@pbcore.video? ? 'video' : 'audio', 
                     controls: true, id: 'player-media',
@@ -67,6 +62,50 @@
     <iframe id="transcript" src="/transcripts/<%= @pbcore.id %>" 
             class="<%= transcript_col_class %>" 
             frameBorder="0" height="400"></iframe>
-  <% end %>    
+  <% elsif !@pbcore.image? %>
+    Untranscribed item: 
+    <span class="btn btn-primary btn-sm" 
+          onclick="$('#request-modal').modal('show');">
+        Request Transcription</span>
+  <% end %>
   <div class="clearfix"></div>
+</div>
+
+<div class="modal fade" id="request-modal" tabindex="-1" role="dialog" aria-labelledby="request-modal-title">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="request-modal-title">Digitization and Transcription Requests</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          You can contribute to the digitization and transcription of materials on Open Vault.
+          Costs vary between items, and digitization may be restricted by copyright,
+          but explain your interests via 
+          <a href="mailto:openvault@wgbh.org?<%=
+            {
+              subject: 'Digitization request',
+              body: 'I am interested in http://openvault.wgbh.org/catalog/' + @pbcore.id
+            }.to_query
+          %>">email</a>, 
+          and we will work with you to make more historic WGBH content available to the world.
+        </p>
+        <p>
+          If you are interested in licensing stock footage please visit
+          <a href="http://wgbhstocksales.org">WGBH Stock Sales</a>, or contact us directly at 
+          <a href="mailto:stock_sales@wgbh.org">stock_sales@wgbh.org</a> or 617-300-3939.
+        </p>
+        <p>
+          If you are a researcher you may schedule an appointment to visit 
+          the WGBH Media Library and Archives in Boston, Massachusetts by emailing
+          <a href="mailto:archive_requests@wgbh.org">archive_requests@wgbh.org</a>.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary" 
+                onclick="$('#request-modal').modal('hide');">
+            Close</button>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
@afred / @caseyedavis12 / @Muraszko ...
How does this look?
<img width="694" alt="screen shot 2016-02-23 at 2 04 52 pm" src="https://cloud.githubusercontent.com/assets/730388/13263260/bca8dc34-da36-11e5-8596-00f1575c8ba3.png">
- This will conflict with #273, so it needs more space between the player and the button, but I don't want to get into that now.
- It's hidden behind, but there's also a button in the missing transcript slot, but they both bring up the same modal.
- Wording is based on Mike's, but adjusted given the context. If it could be shortened, that would be great, but it really shouldn't get any longer.
- In the modal itself, I think it's good to keep the mailtos as links: button-ifying them seems heavy handed.