### PR TITLE
On mobile, keep the fold-down arrow closer to the label.

### DIFF
--- a/app/assets/stylesheets/locals/catalog-index.css.scss
+++ b/app/assets/stylesheets/locals/catalog-index.css.scss
@@ -24,6 +24,11 @@
             }
         }
     }
+    @media (max-width: $screen-sm-max) {
+        #sidebar .panel-title::after {
+            float: none; // Blacklight floats them right, but that's too far if it's the whole screen width.
+        }
+    }
     @media (max-width: $screen-xs-max) {
         .facets-toggle { margin-top: -50px; }
         // Move it up to a more natural location, and then kill the space it would have used.


### PR DESCRIPTION
@afred? on left after, right before:
<img width="759" alt="screen shot 2016-02-23 at 4 33 11 pm" src="https://cloud.githubusercontent.com/assets/730388/13267458/56e7cd46-da4b-11e5-9a19-711f0f2814cb.png">

Another possibility would be to put some kind of box around it on mobile, but with no changes the arrows are just floating out there, and it's not clear what relation there is to the labels.
