### PR TITLE
Keep home carousel from getting too big. Towards #43.

### DIFF
--- a/app/assets/stylesheets/locals/home.css.scss
+++ b/app/assets/stylesheets/locals/home.css.scss
@@ -2,6 +2,22 @@
     
     .carousel {
         margin-top: -1px; // Flash div above inserts a gap.
+        // Set height to half width: not necessary if imgs sized correctly.
+        overflow: hidden;
+        @media ( min-width: $screen-sm-min ) {
+            height: 360px;
+        }
+        @media ( min-width: $screen-md-min ) {
+            height: 472.5px; // Img is same width even in lg.
+        }
+        // Carousel does not show in xs, and I'm ok with that.
+        .carousel-inner {
+            position: absolute;
+            bottom: 0; // If imgs are sized correctly, this is not necessary.
+            img {
+                width: 100%;
+            }
+        }
         .carousel-control {
             background: $transparent;
             padding: 50px 0px;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-12">
+    <div class="col-md-12 col-lg-10 col-lg-offset-1">
       <%= render partial: 'carousel' %>
     </div>
   </div>


### PR DESCRIPTION
@afred? It turns out 10 columns in lg = 12 columns in md, so as you resize the browser across the breakpoint, the carousel remains the same, while everything else changes.
- top: lg
- bottom: md
- right: sm

<img width="1057" alt="screen shot 2016-02-29 at 8 39 52 pm" src="https://cloud.githubusercontent.com/assets/730388/13415021/437ec37a-df25-11e5-9cc7-51b708b2d0d6.png">


