### PR TITLE
Prompt user for more cataloging info. Fix #326.

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -57,6 +57,16 @@
             Boston, MA: WGBH Media Library &amp; Archives.
             Retrieved from <%= url %></dd>
       </dl>
+
+      <div class="well well-sm">
+          If you have more information about this item, we want to know! Please
+          <a href="mailto:openvault@wgbh.org?<%=
+            {
+              subject: "More information about \"#{@pbcore.short_title}\"",
+              body: "http://openvault.wgbh.org/catalog/#{@pbcore.id}"
+            }.to_query
+          %>">contact us</a>, including the URL.
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
@afred?
<img width="765" alt="screen shot 2016-03-01 at 12 35 04 pm" src="https://cloud.githubusercontent.com/assets/730388/13435800/13eb9a7c-dfaa-11e5-9143-60c53a83552e.png">

- At the bottom: if there's lots of data already, this would be a distraction for the vast majority... but if it's scanty, then this is more likely to be above the fold.
- I don't believe this should be a button: first, because the visual emphasis is too much, and also because in the language of the UI, a button suggests a command to the site, when really this is just an invitation to email us.
- Language is based on that for AAPB.