### PR TITLE
Solr highlight

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,8 +10,8 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: 'search',
       rows: 12,
-      :'hl.fl' => 'text',
-      :hl => true
+      'hl.fl': 'text',
+      hl: true
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,7 +9,9 @@ class CatalogController < ApplicationController
     ## See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: 'search',
-      rows: 12
+      rows: 12,
+      :'hl.fl' => 'text',
+      :hl => true
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/views/shared/_document.html.erb
+++ b/app/views/shared/_document.html.erb
@@ -8,3 +8,9 @@
     <%= document[:title] %>
   </div>
 </a>
+
+<% document.response[:highlighting][document.id][:text].each do |html| %>
+  <blockquote>
+    <%= html.html_safe %>
+  </blockquote>
+<% end %>

--- a/app/views/shared/_document.html.erb
+++ b/app/views/shared/_document.html.erb
@@ -9,8 +9,10 @@
   </div>
 </a>
 
-<% document.response[:highlighting][document.id][:text].each do |html| %>
-  <blockquote>
-    <%= html.html_safe %>
-  </blockquote>
+<% document.response[:highlighting][document.id][:text].tap do |highlights| %>
+  <% highlights.each do |highlight| %>
+    <blockquote>
+      <%= highlight.html_safe %>
+    </blockquote>
+  <% end if highlights %>
 <% end %>

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -490,8 +490,8 @@
 
      <formatter name="html" class="org.apache.solr.highlight.HtmlFormatter" default="true">
          <lst name="defaults">
-             <str name="hl.simple.pre"><![CDATA[<b>]]></str>
-             <str name="hl.simple.post"><![CDATA[</b>]]></str>
+             <str name="hl.simple.pre"><![CDATA[<em>]]></str>
+             <str name="hl.simple.post"><![CDATA[</em>]]></str>
          </lst>
      </formatter>
 

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -479,6 +479,23 @@
     </fieldType>
  </types>
 
+ <highlighting>
+     <!-- Configure the standard fragmenter -->
+     <!-- This could most likely be commented out in the "default" case -->
+     <fragmenter name="gap" class="org.apache.solr.highlight.GapFragmenter" default="true">
+         <lst name="defaults">
+             <int name="hl.fragsize">3</int>
+         </lst>
+     </fragmenter>
+
+     <formatter name="html" class="org.apache.solr.highlight.HtmlFormatter" default="true">
+         <lst name="defaults">
+             <str name="hl.simple.pre"><![CDATA[<b>]]></str>
+             <str name="hl.simple.post"><![CDATA[</b>]]></str>
+         </lst>
+     </formatter>
+
+ </highlighting>
 
  <fields>
    <!-- Valid attributes for fields:
@@ -514,7 +531,7 @@
    
    <!-- default, catch all search field -->
    <field name="text" 
-          type="text" indexed="true" stored="false" multiValued="true"/>
+          type="text" indexed="true" stored="true" multiValued="true"/>
    
       
    <!--

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -74,6 +74,13 @@ describe 'Catalog' do
         'An. stays: not an article: sort 0'
       ])
     end
+    
+    it 'highlights keywords in original context' do
+      visit '/catalog?f[access][]=Available+Online&q=evil'
+      expect(page.status_code).to eq(200)
+      expect_fuzzy_xml
+      expect(page).to have_content 'Doctor Evil foo foo foo'
+    end
 
     describe 'support facet ORs' do
       describe 'URL support' do

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -74,7 +74,7 @@ describe 'Catalog' do
         'An. stays: not an article: sort 0'
       ])
     end
-    
+
     it 'highlights keywords in original context' do
       visit '/catalog?f[access][]=Available+Online&q=evil'
       expect(page.status_code).to eq(200)

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -79,7 +79,7 @@ describe 'Catalog' do
       visit '/catalog?f[access][]=Available+Online&q=evil'
       expect(page.status_code).to eq(200)
       expect_fuzzy_xml
-      expect(page).to have_content 'Doctor Evil foo foo foo'
+      expect(page.html).to include 'Doctor <em>Evil</em> foo foo foo'
     end
 
     describe 'support facet ORs' do


### PR DESCRIPTION
@caseyedavis12 : Would highlighting search terms in context be useful to users?
<img width="289" alt="screen shot 2016-03-08 at 3 25 45 pm" src="https://cloud.githubusercontent.com/assets/730388/13615182/240eefba-e542-11e5-865d-5728cc09bd94.png">

If so, what should it look like?

@afred : This does make the index large, since the transcript needs to be stored, not just indexed. Is this a concern?