### PR TITLE
I just made this same change on AWS.

### DIFF
--- a/spec/fixtures/aws/bucket-policy.json
+++ b/spec/fixtures/aws/bucket-policy.json
@@ -16,7 +16,7 @@
       "Effect": "Deny",
       "Principal": "*",
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::openvault.wgbh.org/*",
+      "Resource": "arn:aws:s3:::openvault.wgbh.org/catalog/*",
       "Condition": {
         "StringNotLike": {
           "aws:Referer": [


### PR DESCRIPTION
@afred? The goal is to allow access to stuff under /resources, like https://s3.amazonaws.com/openvault.wgbh.org/resources/reports/mellon_assessment.pdf. Since we have several top level directories, if we really wanted to protect all the other ones, we we need a rule for each, and that would be hard to maintain... but I think we're really only concerned about /catalog. 
