### PR TITLE
button style. Fix #357.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,8 +15,8 @@
  */
 
 @import "globals/fonts";
-@import "globals/defaults";
 @import "globals/colors";
+@import "globals/defaults";
 
 @import 'blacklight'; // Before locals so it can be over-ridden; after globals so it has variables.
 

--- a/app/assets/stylesheets/globals/defaults.css.scss
+++ b/app/assets/stylesheets/globals/defaults.css.scss
@@ -8,4 +8,8 @@ html > body {
         font-size: 48px;
         padding-bottom: 20px;
     }
+    .btn-primary {
+        background: $medium-blue;
+        border: none;
+    }
 }


### PR DESCRIPTION
@afred? Had to change the load order so that color definitions are available. Dark blue was too dark. Having border of a different color looked odd (If we had a gradient across the button it might be ok) ... so I just left it off.

<img width="376" alt="screen shot 2016-03-10 at 11 33 53 am" src="https://cloud.githubusercontent.com/assets/730388/13676560/604a7184-e6b4-11e5-9b20-fa4201d84a86.png">
