### PR TITLE
We had a row inside a row. Fix #429.

### DIFF
--- a/app/views/shared/_grid.html.erb
+++ b/app/views/shared/_grid.html.erb
@@ -1,4 +1,4 @@
-<div class="documents row">
+<div class="documents">
   <%
     grid = 12 # Needs to match bootstrap's $grid-columns
     col_classes = cols.map { |k,v| "col-#{k}-#{grid / v}"}.join(' ')


### PR DESCRIPTION
@afred? before / after:

<img width="493" alt="screen shot 2016-03-11 at 3 01 38 pm" src="https://cloud.githubusercontent.com/assets/730388/13714058/47e3e026-e79a-11e5-8620-d5afe3c7d7b9.png">
