### PR TITLE
More aggresive line breaks. Fix #440.

### DIFF
--- a/app/assets/stylesheets/globals/defaults.css.scss
+++ b/app/assets/stylesheets/globals/defaults.css.scss
@@ -18,4 +18,20 @@ html > body {
         background: $medium-blue;
         border: none;
     }
+    
+    // Mostly for line-breaking long URLs in citation, when viewed on mobile.
+    // I think in a URL, hyphens could be confusing... 
+    // We could add a special class to supress hyphenation only on URLs?
+    
+    // From: https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+    
+    /* These are technically the same, but use both */
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
+    -ms-word-break: break-all;
+    /* This is the dangerous one in WebKit, as it breaks things wherever */
+    word-break: break-all;
+    /* Instead use this non-standard one: */
+    word-break: break-word;
 }


### PR DESCRIPTION
@afred? Screen shot from Chrome:
<img width="342" alt="screen shot 2016-03-14 at 1 32 45 pm" src="https://cloud.githubusercontent.com/assets/730388/13753430/431abe06-e9e9-11e5-9dc0-19c4adc6ea14.png">
