### PR TITLE
remember ORR confirmation

### DIFF
--- a/app/views/catalog/_password_modal.html.erb
+++ b/app/views/catalog/_password_modal.html.erb
@@ -1,36 +1,39 @@
-<div class="modal fade" id="password-modal" tabindex="-1" role="dialog" aria-labelledby="password-modal-title">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4 class="modal-title" id="password-modal-title">Password Required</h4>
-      </div>
-      <div class="modal-body">
-          <p>
-            To access this material, 
-            please read the Rules of Use,
-            indicate your agreement,
-            and provide the password. 
-          </p>
-          <p>
-            Your password is:
-            <script>document.write('<span id="hint">'+Math.random().toString(36).slice(2)+'</span>');</script>
-          </p>
-        <iframe src="/plain/rules-of-use" style="width: 100%;"></iframe>
-      </div>
-      <div class="modal-footer">
-        I have read and agree to the terms and conditions:
-        <input id="read-and-agree" type="checkbox"></input>
-        <input id="password" type="password" placeholder="Password from above"></input>
-        <button type="submit" class="btn btn-primary" onclick="
-          // When I copy-and-paste, I get a space character at the beginging...
-          // not sure why, but replace cleans it up.
-          if ($('#password').val().replace(/\W/g,'') === $('#hint').text() &amp;&amp; $('#read-and-agree').is(':checked')) {
-            $('#password-modal').modal('hide');
-          } else {
-            alert('Please confirm your agreement and provide the password.');
-          }
-        ">Enter</button>
+<% 'orr_rules_of_use'.tap do |cookie_name| %>
+  <% if !cookies[cookie_name] %>
+    <div class="modal fade" id="password-modal" tabindex="-1" role="dialog" aria-labelledby="password-modal-title">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="password-modal-title">Password Required</h4>
+          </div>
+          <div class="modal-body">
+              <p>
+                To access this material, please read the Rules of Use,
+                indicate your agreement, and provide the password. 
+              </p>
+              <p>
+                Your password is:
+                <script>document.write('<span id="hint">'+Math.random().toString(36).slice(2)+'</span>');</script>
+              </p>
+            <iframe src="/plain/rules-of-use" style="width: 100%;"></iframe>
+          </div>
+          <div class="modal-footer">
+            I have read and agree to the terms and conditions:
+            <input id="read-and-agree" type="checkbox"></input>
+            <input id="password" type="password" placeholder="Password from above"></input>
+            <button type="submit" class="btn btn-primary" onclick="
+              // When I copy-and-paste, I get a space character at the beginging...
+              // not sure why, but replace cleans it up.
+              if ($('#password').val().replace(/\W/g,'') === $('#hint').text() &amp;&amp; $('#read-and-agree').is(':checked')) {
+                document.cookie = '<%= cookie_name %>=y;max-age=<%= 60*60 %>'
+                $('#password-modal').modal('hide');
+              } else {
+                alert('Please confirm your agreement and provide the password.');
+              }
+            ">Enter</button>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</div>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Like the find-help widget, remember confirmation in a client-only cookie. Fix #428. @afred?