### PR TITLE
Tab capitalization

### DIFF
--- a/app/assets/stylesheets/locals/collections-exhibits.css.scss
+++ b/app/assets/stylesheets/locals/collections-exhibits.css.scss
@@ -107,8 +107,9 @@
             font-weight: $medium;
             li .pointer {
                 position: absolute;
-                left: 0px;
+                left: 15px;
             }
+            padding-left: 40px;
         }
         
     }

--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -1,7 +1,7 @@
 class Exhibit < Tabbed
   ROOT = File.expand_path('../views/exhibits', File.dirname(__FILE__))
   def author
-    @author ||= tabs['author'][:content].gsub(/<[^>]*>/, '')
+    @author ||= tabs['author'].content.gsub(/<[^>]*>/, '')
     # TODO: Use xpath.
   end
 end

--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -1,7 +1,7 @@
 class Exhibit < Tabbed
   ROOT = File.expand_path('../views/exhibits', File.dirname(__FILE__))
   def author
-    @author ||= tabs['author'].gsub(/<[^>]*>/, '')
+    @author ||= tabs['author'][:content].gsub(/<[^>]*>/, '')
     # TODO: Use xpath.
   end
 end

--- a/app/models/tabbed.rb
+++ b/app/models/tabbed.rb
@@ -11,6 +11,8 @@ class Tabbed < Cmless
     raise "Problem with #{title}: #{$ERROR_INFO}"
   end
 
+  Tab = Struct.new(:title, :content)
+  
   def tabs
     @tabs ||= begin
       doc = Nokogiri::HTML(body_html)
@@ -20,15 +22,14 @@ class Tabbed < Cmless
           tab_html = Cmless.extract_html(doc, tab_title)
           [
             Tabbed.norm(tab_title),
-            {
-              title: tab_title,
-              content: 
-                begin
-                  Tabbed.expand_links(tab_html)
-                rescue NotACatalogLink
-                  tab_html
-                end
-            }
+            Tab.new(
+              tab_title,
+              begin
+                Tabbed.expand_links(tab_html)
+              rescue NotACatalogLink
+                tab_html
+              end
+            )
           ]
         end
       ]

--- a/app/models/tabbed.rb
+++ b/app/models/tabbed.rb
@@ -12,7 +12,7 @@ class Tabbed < Cmless
   end
 
   Tab = Struct.new(:title, :content)
-  
+
   def tabs
     @tabs ||= begin
       doc = Nokogiri::HTML(body_html)

--- a/app/models/tabbed.rb
+++ b/app/models/tabbed.rb
@@ -16,15 +16,19 @@ class Tabbed < Cmless
       doc = Nokogiri::HTML(body_html)
       Hash[
         doc.xpath('//h2').map do |tab_el|
-          tab_text = tab_el.text
-          tab_html = Cmless.extract_html(doc, tab_text)
+          tab_title = tab_el.text
+          tab_html = Cmless.extract_html(doc, tab_title)
           [
-            self.class.norm(tab_text),
-            begin
-              Tabbed.expand_links(tab_html)
-            rescue NotACatalogLink
-              tab_html
-            end
+            Tabbed.norm(tab_title),
+            {
+              title: tab_title,
+              content: 
+                begin
+                  Tabbed.expand_links(tab_html)
+                rescue NotACatalogLink
+                  tab_html
+                end
+            }
           ]
         end
       ]

--- a/app/views/collections/stock-sales.md
+++ b/app/views/collections/stock-sales.md
@@ -10,8 +10,6 @@
 
 Search and browse thousands of WGBH clips available to license! Click on the thumbnails below to screen examples:
 
-## Examples
-
 <div class="document col-md-4 col-sm-6">
     <a href="http://www.wgbhstocksales.org/catalog/GBH00000082001013">
         <img src="https://s3.amazonaws.com/openvault.wgbh.org/special_collections/stock_sales/GBH00000082001013.png"/>

--- a/app/views/shared/_above_tabs.html.erb
+++ b/app/views/shared/_above_tabs.html.erb
@@ -13,5 +13,5 @@
 </div>
 
 <div>
-  <%= item.tabs['intro'].html_safe %>
+  <%= item.tabs['intro'][:content].html_safe %>
 </div>

--- a/app/views/shared/_above_tabs.html.erb
+++ b/app/views/shared/_above_tabs.html.erb
@@ -13,5 +13,5 @@
 </div>
 
 <div>
-  <%= item.tabs['intro'][:content].html_safe %>
+  <%= item.tabs['intro'].content.html_safe %>
 </div>

--- a/app/views/shared/_collection_exhibit_show.html.erb
+++ b/app/views/shared/_collection_exhibit_show.html.erb
@@ -12,7 +12,7 @@
   </div>
   <%= render partial: 'shared/tab_row', locals: {item: item, skip: ['intro', 'extra', 'author']}%>
   <div class="row">
-    <% item.tabs[params[:tab]][:content].tap do |current_tab| %>
+    <% item.tabs[params[:tab]].content.tap do |current_tab| %>
       <% if current_tab.respond_to?(:each) %>
         <% top_docs = current_tab[0..11] %>
         <% other_docs = current_tab[12..-1] %>

--- a/app/views/shared/_collection_exhibit_show.html.erb
+++ b/app/views/shared/_collection_exhibit_show.html.erb
@@ -33,6 +33,6 @@
           <%= current_tab.html_safe if current_tab %>
         </div>
       <% end %>
-    <% end %>
+    <% end if params[:tab] %>
   </div>
 </div>

--- a/app/views/shared/_collection_exhibit_show.html.erb
+++ b/app/views/shared/_collection_exhibit_show.html.erb
@@ -12,7 +12,7 @@
   </div>
   <%= render partial: 'shared/tab_row', locals: {item: item, skip: ['intro', 'extra', 'author']}%>
   <div class="row">
-    <% item.tabs[params[:tab]].tap do |current_tab| %>
+    <% item.tabs[params[:tab]][:content].tap do |current_tab| %>
       <% if current_tab.respond_to?(:each) %>
         <% top_docs = current_tab[0..11] %>
         <% other_docs = current_tab[12..-1] %>

--- a/app/views/shared/_collection_exhibit_show.html.erb
+++ b/app/views/shared/_collection_exhibit_show.html.erb
@@ -10,29 +10,31 @@
       <%= render partial: 'shared/above_tabs', locals: {item: item} %>
     </div>
   </div>
-  <%= render partial: 'shared/tab_row', locals: {item: item, skip: ['intro', 'extra', 'author']}%>
-  <div class="row">
-    <% item.tabs[params[:tab]].content.tap do |current_tab| %>
-      <% if current_tab.respond_to?(:each) %>
-        <% top_docs = current_tab[0..11] %>
-        <% other_docs = current_tab[12..-1] %>
-        <%= render partial: 'shared/document_grid', locals: {documents: top_docs} %>
-        <% if other_docs && !other_docs.empty? %>
-        <div class="clearfix"></div>
-          <p>And <%= other_docs.count %> more...</p>
-          <% other_docs.in_groups(2, false).each do |docs_col| %>
-            <div class="col-sm-6">
-              <% docs_col.each do |doc| %>
-                <a href="/catalog/<%= doc.id %>"><%= doc.title %></a><br/>
-              <% end %>
-            </div>
+  <% if params[:tab] %>
+    <%= render partial: 'shared/tab_row', locals: {item: item, skip: ['intro', 'extra', 'author']}%>
+    <div class="row">
+      <% item.tabs[params[:tab]].content.tap do |current_tab| %>
+        <% if current_tab.respond_to?(:each) %>
+          <% top_docs = current_tab[0..11] %>
+          <% other_docs = current_tab[12..-1] %>
+          <%= render partial: 'shared/document_grid', locals: {documents: top_docs} %>
+          <% if other_docs && !other_docs.empty? %>
+          <div class="clearfix"></div>
+            <p>And <%= other_docs.count %> more...</p>
+            <% other_docs.in_groups(2, false).each do |docs_col| %>
+              <div class="col-sm-6">
+                <% docs_col.each do |doc| %>
+                  <a href="/catalog/<%= doc.id %>"><%= doc.title %></a><br/>
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
+        <% else %>
+          <div class="<%= col_class %>">
+            <%= current_tab.html_safe if current_tab %>
+          </div>
         <% end %>
-      <% else %>
-        <div class="<%= col_class %>">
-          <%= current_tab.html_safe if current_tab %>
-        </div>
       <% end %>
-    <% end if params[:tab] %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/shared/_tab_row.html.erb
+++ b/app/views/shared/_tab_row.html.erb
@@ -2,7 +2,7 @@
 <ul id="<%= anchor %>">
   <% (item.tabs.keys).reject { |x| skip.include?(x) }.tap do |tabs|
     tabs.each do |tab| 
-      title = item.tabs[tab][:title] %>
+      title = item.tabs[tab].title %>
       <li>
         <% unless tab == params[:tab] %>
           <a href="<%= tab %>#<%= anchor %>" >

--- a/app/views/shared/_tab_row.html.erb
+++ b/app/views/shared/_tab_row.html.erb
@@ -1,18 +1,13 @@
-<% anchor = 'tabs' %>
-<ul id="<%= anchor %>">
-  <% (item.tabs.keys).reject { |x| skip.include?(x) }.tap do |tabs|
-    tabs.each do |tab| 
-      title = item.tabs[tab].title %>
-      <li>
-        <% unless tab == params[:tab] %>
-          <a href="<%= tab %>#<%= anchor %>" >
-            <%= title %>
-          </a>
-        <% else %>
-          <span class="pointer">&#x25B6;</span>
-          <%= title %>
-        <% end %>
-      </li>
-    <% end if tabs.count > 1
-    end %>
-</ul>
+<% if item.tabs.count > 1 %>
+  <% anchor = 'tabs' %>
+  <ul id="<%= anchor %>" class="well col-md-4">
+    <% item.tabs.each do |key,tab|
+        next if skip.include?(key)
+        selected = key == params[:tab] %>
+        <li>
+          <% if selected %><span class="pointer">&#x25B6;</span><% end %>
+          <%= link_to_unless(selected, tab.title, "#{key}##{anchor}" ) %>
+        </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/shared/_tab_row.html.erb
+++ b/app/views/shared/_tab_row.html.erb
@@ -1,15 +1,16 @@
 <% anchor = 'tabs' %>
 <ul id="<%= anchor %>">
   <% (item.tabs.keys).reject { |x| skip.include?(x) }.tap do |tabs|
-    tabs.each do |tab| %>
+    tabs.each do |tab| 
+      title = item.tabs[tab][:title] %>
       <li>
         <% unless tab == params[:tab] %>
           <a href="<%= tab %>#<%= anchor %>" >
-            <%= tab.titlecase %>
+            <%= title %>
           </a>
         <% else %>
           <span class="pointer">&#x25B6;</span>
-          <%= tab.titlecase %>
+          <%= title %>
         <% end %>
       </li>
     <% end if tabs.count > 1

--- a/spec/features/tabs_spec.rb
+++ b/spec/features/tabs_spec.rb
@@ -9,7 +9,7 @@ describe 'Tab Pages' do
     all.each do |tabbed|
       describe tabbed.title do
         "/#{top}/#{tabbed.path}".tap do |target|
-          if target =~ /boston-tv-news|american-archive-of-public-broadcasting/
+          if target =~ /boston-tv-news|american-archive-of-public-broadcasting|stock-sales/
             it "doesn't redirect special #{target}" do
               visit target
               expect(page.status_code).to eq(200)


### PR DESCRIPTION
@afred? The first commit is a change in the logic: The tabs had just been a simple hash, and for the display title we would reconstruct it from the key. This worked fine except for "ERN Coverage", because the key was "ern-coverage", and the capitalization could only make it "Ern Coverage". --> Now, however, the values in the hash are `Tab` structs which have the content, and the correct title.
<img width="619" alt="screen shot 2016-03-16 at 12 31 59 pm" src="https://cloud.githubusercontent.com/assets/730388/13821009/39be849e-eb76-11e5-9b03-d33baab4b013.png">

The rest of the commits are code clarity, and looks.