### PR TITLE
margin was overriding BL defaults. 

### DIFF
--- a/app/assets/stylesheets/locals/home.css.scss
+++ b/app/assets/stylesheets/locals/home.css.scss
@@ -44,7 +44,7 @@
     }
     
     #nav-button-container {
-        margin: 66px 0;
+        padding-top: 66px;
         a h2 {
             color: $dark-blue;
             font-size: 36px; // TODO: This causes line wrapping in md.


### PR DESCRIPTION
Now buttons are aligned with carousel again. @afred?

<img width="43" alt="screen shot 2016-03-16 at 3 45 26 pm" src="https://cloud.githubusercontent.com/assets/730388/13826467/2751402c-eb8e-11e5-9c95-2416a3c693a7.png">
