### PR TITLE
grid bottom padding

### DIFF
--- a/app/assets/stylesheets/locals/catalog-index.css.scss
+++ b/app/assets/stylesheets/locals/catalog-index.css.scss
@@ -144,7 +144,7 @@
             }
             .info {
                color: $dark-blue;
-               padding: $grid-gutter-width*0.5 0;
+               padding: 15px 0 50px;
             }
         }
         .record-padding {


### PR DESCRIPTION
Also, get rid of sass var, rather than mixing vars and constants. @afred? Fix #441.