### PR TITLE
less margin/padding on mobile. All fits on the screen.

### DIFF
--- a/app/assets/stylesheets/locals/home.css.scss
+++ b/app/assets/stylesheets/locals/home.css.scss
@@ -48,9 +48,13 @@
     
     #nav-button-container {
         padding-top: 66px;
+        @media (max-width: $screen-xs-max) {
+            padding: 0;
+            margin: 0;
+        }
         a h2 {
             color: $dark-blue;
-            font-size: 36px; // TODO: This causes line wrapping in md.
+            font-size: 36px;
             background: $yellow;
             &:hover { background: $pale-yellow; }
             @media (min-width: $screen-lg-min) {
@@ -58,6 +62,10 @@
             }
             @media (max-width: $screen-md-max) {
                 padding: 1em 1.2em; // Excessive side padding, to force all to wrap.
+            }
+            @media (max-width: $screen-xs-max) {
+                padding: 0.5em 0em;
+                font-size: 24px;
             }
             font-weight: $semibold;
         }
@@ -67,6 +75,10 @@
     #about {
         margin: 80px 0;
         padding: 40px;
+        @media (max-width: $screen-xs-max) {
+            padding: 0.5em;
+            margin: 1em;
+        }
         background: $light-grey;
         color: #FFF;
         a { 


### PR DESCRIPTION
@afred?
<img width="665" alt="screen shot 2016-03-18 at 10 30 04 am" src="https://cloud.githubusercontent.com/assets/730388/13880837/9e304b2c-ecf4-11e5-854f-7873dd611358.png">
