### PR TITLE
On the pages where it matters, make the title boxes all the same size

### DIFF
--- a/app/assets/javascripts/uniform-height.js
+++ b/app/assets/javascripts/uniform-height.js
@@ -1,0 +1,10 @@
+$(function(){
+    var $infos = $('.blacklight-collections .info, .blacklight-exhibits .info');
+    var heights = $.map(
+            $infos,
+            function (el) {
+                return $(el).height();
+            }
+        );
+    $infos.height(Math.max.apply(null, heights));
+});


### PR DESCRIPTION
@afred? I know we've considered different approaches, and there's nothing magic about this. Fix #281.

I really would prefer not to change the html we produce at this point, and I'm not sure if there is a pure css solution. This does apply the same height for the whole grid, and not just per-cell, and maybe that's not a bad thing.