### PR TITLE
Formatting of collection/exhibit lists. Fix #548.

### DIFF
--- a/app/assets/stylesheets/locals/collections-exhibits.css.scss
+++ b/app/assets/stylesheets/locals/collections-exhibits.css.scss
@@ -86,6 +86,11 @@
         #documents .document {
             border: none;
         }
+        .no-thumbs a {
+            display: block;
+            margin-left: 2em;
+            text-indent: -2em;
+        }
         
         iframe {
             // (For embeds)

--- a/app/views/shared/_collection_exhibit_show.html.erb
+++ b/app/views/shared/_collection_exhibit_show.html.erb
@@ -18,15 +18,18 @@
         <% other_docs = current_tab[12..-1] %>
         <%= render partial: 'shared/document_grid', locals: {documents: top_docs} %>
         <% if other_docs && !other_docs.empty? %>
-        <div class="clearfix"></div>
-          <p>And <%= other_docs.count %> more...</p>
-          <% other_docs.in_groups(2, false).each do |docs_col| %>
-            <div class="col-sm-6">
-              <% docs_col.each do |doc| %>
-                <a href="/catalog/<%= doc.id %>"><%= doc.title %></a><br/>
-              <% end %>
-            </div>
-          <% end %>
+          <div class="row">
+            <div class="col-sm-12">And <%= other_docs.count %> more...</div>
+          </div>
+          <div class="row no-thumbs">
+            <% other_docs.in_groups(2, false).each do |docs_col| %>
+              <div class="col-md-6">
+                <% docs_col.each do |doc| %>
+                  <a href="/catalog/<%= doc.id %>"><%= doc.title %></a>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
         <% end %>
       <% else %>
         <div class="<%= col_class %>">


### PR DESCRIPTION
Use BL classes more consistently. CSS for indentation.

@afred or @Muraszko ?

after / before: 
<img width="813" alt="screen shot 2016-03-28 at 12 02 44 pm" src="https://cloud.githubusercontent.com/assets/730388/14082278/1be45050-f4dd-11e5-8cba-4c4f910b8dcb.png">
