### PR TITLE
Maybe catch 500s

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,4 +29,6 @@ class ApplicationController < ActionController::Base
   def render_404
     render file: 'public/404.html', status: :not_found
   end
+
+  rescue_from StandardError, with: :render_404
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,9 +4,15 @@ require_relative '../../lib/geo_i_p_country'
 class CatalogController < ApplicationController
   include Blacklight::Catalog
 
-  # This overrides default behavior from the Blacklight::Catalog module in the
-  # blacklight gem. Method defined below.
-  rescue_from Blacklight::Exceptions::RecordNotFound, with: :record_not_found
+  # This shouldn't be necessary, since it's also specified in ApplicationController...
+  # but I must be missing something.
+  rescue_from StandardError, with: :render_404
+
+  # Callback for Blacklight Catalog controller. Acts as a passthru to
+  # ApplicationController#render_404, which is the common 404 method.
+  def record_not_found(_exception)
+    render_404
+  end
 
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests.
@@ -184,11 +190,5 @@ class CatalogController < ApplicationController
         render text: xml
       end
     end
-  end
-
-  # Callback for Blacklight Catalog controller. Acts as a passthru to
-  # ApplicationController#render_404, which is the common 404 method.
-  def record_not_found(_exception)
-    render_404
   end
 end

--- a/app/controllers/override_controller.rb
+++ b/app/controllers/override_controller.rb
@@ -1,10 +1,6 @@
 class OverrideController < ApplicationController
   def show
-    begin
-      @override = Override.find_by_path(params[:path])
-    rescue IndexError
-      return render_404
-    end
+    @override = Override.find_by_path(params[:path])
 
     @page_title = @override.title
     params[:path] = nil # search widget grabs ALL parameters.

--- a/app/controllers/tabbed_controller.rb
+++ b/app/controllers/tabbed_controller.rb
@@ -4,11 +4,7 @@ class TabbedController < ApplicationController
   end
 
   def show
-    begin
-      @item = tab_class.find_by_path(params[:id])
-    rescue IndexError
-      raise ActiveRecord::RecordNotFound
-    end
+    @item = tab_class.find_by_path(params[:id])
     @page_title = @item.title
 
     if params[:tab]

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -112,6 +112,11 @@ describe 'Catalog' do
         end
       end
     end
+
+    it 'Gives 404 for bad query' do
+      visit '/catalog?f[access]='
+      expect(page.status_code).to eq(404)
+    end
   end
 
   describe '#show' do
@@ -132,6 +137,11 @@ describe 'Catalog' do
     it 'Respects line-breaks in source data' do
       visit '/catalog/A_00B0C50853C64A71935737EF7A4DA66C'
       expect(page.html).to match(/<p>Line breaks\s+do not matter, but<\/p><p>empty lines do\.<\/p>/)
+    end
+
+    it 'Gives 404 for bad item' do
+      visit '/catalog/nope'
+      expect(page.status_code).to eq(404)
     end
   end
 end

--- a/spec/features/override_spec.rb
+++ b/spec/features/override_spec.rb
@@ -14,4 +14,9 @@ describe 'Overrides' do
         expect_fuzzy_xml
       end
     end
+
+  it 'Gives 404 for no such page' do
+    visit '/nothing/here'
+    expect(page.status_code).to eq(404)
+  end
 end

--- a/spec/features/tabs_spec.rb
+++ b/spec/features/tabs_spec.rb
@@ -24,10 +24,10 @@ describe 'Tab Pages' do
               expect_fuzzy_xml
             end
           end
-        end
-        it 'Gives 404 for bad tab' do
-          visit target + '/bad'
-          expect(page.status_code).to eq(404)
+          it 'Gives 404 for bad tab' do
+            visit target + '/bad'
+            expect(page.status_code).to eq(404)
+          end
         end
         (tabbed.tabs.keys - %w(intro extra)).each do |path|
           "/#{top}/#{tabbed.path}/#{path}".tap do |target|
@@ -40,21 +40,6 @@ describe 'Tab Pages' do
           end
         end
       end
-    end
-  end
-
-  describe 'Bad tab 404' do
-    it '404s if tab on no-tab page' do
-      base = '/collections/boston-tv-news'
-      visit(base)
-      expect(page.status_code).to eq(200)
-      expect { visit(base + '/nope') }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-    it '404s if tab on no-tab page' do
-      base = '/collections/advocates'
-      visit(base)
-      expect(page.status_code).to eq(200) # Will have redirected
-      expect { visit(base + '/nope') }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/features/tabs_spec.rb
+++ b/spec/features/tabs_spec.rb
@@ -25,6 +25,10 @@ describe 'Tab Pages' do
             end
           end
         end
+        it 'Gives 404 for bad tab' do
+          visit target + '/bad'
+          expect(page.status_code).to eq(404)
+        end
         (tabbed.tabs.keys - %w(intro extra)).each do |path|
           "/#{top}/#{tabbed.path}/#{path}".tap do |target|
             it "loads #{target}" do
@@ -51,6 +55,13 @@ describe 'Tab Pages' do
       visit(base)
       expect(page.status_code).to eq(200) # Will have redirected
       expect { visit(base + '/nope') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  %w(exhibit collection).each do |base|
+    it "Gives 404 for bad #{base}" do
+      visit "/#{base}/bad"
+      expect(page.status_code).to eq(404)
     end
   end
 end


### PR DESCRIPTION
@afred? Right now I rescue_from StandardError... but if we want to scale it back and only capture particular error classes that we expect, that would be ok, too.