### PR TITLE
Carousel JPEGs

### DIFF
--- a/app/views/home/carousel.md
+++ b/app/views/home/carousel.md
@@ -1,5 +1,5 @@
 # Carousel
 
-- [![The Vietnam Collection](https://s3.amazonaws.com/openvault.wgbh.org/carousel/carousel_vietnam.png)](/collections/vietnam/interviews)
-- [![March on Washington](https://s3.amazonaws.com/openvault.wgbh.org/carousel/carousel_march.png)](/collections/march_on_washington/ern-coverage)
-- [![Rock and Roll](https://s3.amazonaws.com/openvault.wgbh.org/carousel/carousel_guitar.png)](/collections/rock_roll/interviews)
+- [![The Vietnam Collection](https://s3.amazonaws.com/openvault.wgbh.org/carousel/carousel_vietnam-q-80.jpg)](/collections/vietnam/interviews)
+- [![March on Washington](https://s3.amazonaws.com/openvault.wgbh.org/carousel/carousel_march-q-80.jpg)](/collections/march_on_washington/ern-coverage)
+- [![Rock and Roll](https://s3.amazonaws.com/openvault.wgbh.org/carousel/carousel_guitar-q-80.jpg)](/collections/rock_roll/interviews)


### PR DESCRIPTION
@afred / @caseyedavis12: Using a more appropriate image format will really improve experience for some users who land on the home page:

```
 136 carousel_guitar-q-80.jpg
2032 carousel_guitar.png
 216 carousel_march-q-80.jpg
1376 carousel_march.png
 136 carousel_vietnam-q-80.jpg
2040 carousel_vietnam.png
```

(Look at chrome dev tools to get a sense of what it's like on a not-fast connection.)

Not compressing quite as aggressively as on the collections/exhibits: with more time to look at the image, the artifacts can be more apparent here, so it's a trade off. Both vietnam and the march images have some high contrast areas where fringing might be seen... the guitar on the other hand is so grainy to begin with that I don't think it makes much of a difference.

(Not going to put the images here: they're already on S3, and part of the question is also the zoom we apply.)