### PR TITLE
Transcripts with br 569

### DIFF
--- a/app/controllers/transcripts_controller.rb
+++ b/app/controllers/transcripts_controller.rb
@@ -18,7 +18,7 @@ class TranscriptsController < ApplicationController
         ugly_xml = XSLT.transform(tei_doc).to_xml
         @transcript_html = Nokogiri::XML(ugly_xml) do |config|
           config.options = Nokogiri::XML::ParseOptions::NOBLANKS
-        end.to_xml.sub('<?xml version="1.0"?>', '').sub('xmlns:xhtml="http://www.w3.org/1999/xhtml"', '')
+        end.to_xml.sub('<?xml version="1.0" encoding="utf-8"?>', '').sub('xmlns:xhtml="http://www.w3.org/1999/xhtml"', '')
         render
       end
       format.xml do

--- a/lib/xslt/tei_to_html.xsl
+++ b/lib/xslt/tei_to_html.xsl
@@ -5,7 +5,7 @@
   xmlns:smil="http://www.w3.org/2001/SMIL20/Language"
   xmlns:xhtml="http://www.w3.org/1999/xhtml"
   exclude-result-prefixes="tei smil">
-  <xsl:output method="html" encoding="utf-8" indent="yes" />
+  <xsl:output method="xml" encoding="utf-8"/>
   <xsl:variable name="persNames" select="//tei:person" />
   <xsl:key name="teiRef" match="//tei:term" use="@xml:id" />
 

--- a/public/404.html.erb
+++ b/public/404.html.erb
@@ -1,4 +1,5 @@
 <div class="col-lg-12 not_found_404">
   I'm sorry, there's nothing here. Please try searching above,
-  or browse the <a href="/exhibits" alt="scholar exhibits">exhibits</a> and <a href="/collections" alt="special collections">collections</a>.
+  or browse the <a href="/exhibits" alt="scholar exhibits" target="_top">exhibits</a>
+  and <a href="/collections" alt="special collections" target="_top">collections</a>.
 </div>

--- a/spec/fixtures/transcript/mock-transcript.html
+++ b/spec/fixtures/transcript/mock-transcript.html
@@ -24,6 +24,7 @@
                         
 </div>
           <div id="para3" class="para" data-timecodebegin="00:00:20" data-timecodeend="00:00:30"><span class="play-from-here" data-timecode="00:00:20"/><a href="http://i.am.ok/does-not-matter" title="Baz, 2015-2016" target="_blank">baz</a>.
+                            <br/>Translates to br in html: self closing tags can be parse problems.
                         
 </div>
         </div>

--- a/spec/fixtures/transcript/mock-transcript.xml
+++ b/spec/fixtures/transcript/mock-transcript.xml
@@ -31,6 +31,7 @@
                         </seg>
                         <seg xml:id="para3" smil:begin="00:00:20" smil:end="00:00:30">
                             <name ref="#baz">baz</name>.
+                            <lb/>Translates to br in html: self closing tags can be parse problems.
                         </seg>
                     </u>
                 </div>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -184,7 +184,7 @@ describe 'Validated and plain PBCore' do
                                            'RIGHTS-SUMMARY',
                                            'war_peace', 'War and Peace in the Nuclear Age',
                                            'needlework', 'Erica Wilson: The Julia Child of Needlework',
-                                           'Foo, 2015-2016 Bar, 2015-2016 Baz, 2015-2016 Doctor Evil foo ! bar ? baz .'])
+                                           'Foo, 2015-2016 Bar, 2015-2016 Baz, 2015-2016 Doctor Evil foo ! bar ? baz . Translates to br in html: self closing tags can be parse problems.'])
 
       pbc = PBCore.new(pbc_xml)
 


### PR DESCRIPTION
@afred? The heart of the problem was that we output HTML from XSL, and then tried to reparse that as XML for the sake of pretty-printing, which usually worked, unless the output contained an unpaired `<br>`.