### PR TITLE
Use PBCore#thumbnail_src in catalog index

### DIFF
--- a/app/views/shared/_document.html.erb
+++ b/app/views/shared/_document.html.erb
@@ -1,7 +1,7 @@
 <a href="/catalog/<%= document.id %>">
   <div class="aspect-ratio-4x3">
     <div class="aspect-ratio-content">
-      <img src="<%= document[:thumbnail_src] %>">
+      <img src="<%= PBCore.new(document[:xml]).thumbnail_src %>">
       <% (@highlighting || {})[document.id].tap do |highlight_html| %>
         <% if highlight_html %>
           <div class="highlight">


### PR DESCRIPTION
Was using the 'thumbnail_src' element of the Solr document, which requires a
reingest if the thumbnail_src changes, which it did for default audio and video
thumbs. So this saves a re-ingest.