### PR TITLE
Donate button in header

### DIFF
--- a/app/assets/stylesheets/locals/header-footer.css.scss
+++ b/app/assets/stylesheets/locals/header-footer.css.scss
@@ -17,11 +17,13 @@
         left: 240px;
         top: 7px;
     }
+    .nav { padding-left: 2em; }
     .nav a {
-        margin-left: 2em;
+        margin-left: 1em;
         font-size: 22px;
         font-weight: $medium;
         &:hover { color: $yellow; }
+        &#donate { color: $yellow; }
     }
 }
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,9 +13,10 @@
         </form>
       </div>
       <div class="col-md-9 hidden-sm hidden-xs nav">
-        <%= link_to(t('series'), '/series') %>
+        <%= link_to(t('series_short'), '/series') %>
         <%= link_to(t('exhibits'), '/exhibits') %>
         <%= link_to(t('collections'), '/collections') %>
+        <%= link_to(t('donate'), '/donate', id: 'donate') %>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,5 +21,7 @@
 
 en:
   series: WGBH Series
+  series_short: Series
   exhibits: Scholar Exhibits
   collections: Special Collections
+  donate: Donate


### PR DESCRIPTION
<img width="660" alt="screen shot 2016-04-26 at 4 51 44 pm" src="https://cloud.githubusercontent.com/assets/730388/14833874/4db013ae-0bcf-11e6-83ed-9db8fc7729a5.png">

downsides:
- Needed to shorten "WGBH Series" to just "Series"
- reduced space / more clutter
- not on mobile
- yellow in the banner hasn't been a highlight color before now, instead reserved as a hover. (Tried the red, but that's too dark.)

I'll make another PR as an alternative: Rather than always putting it in the header, reserve it for item pages, when someone has found something they actually value.
