### PR TITLE
Disambiguating kimbia.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -29,3 +29,4 @@
 @import "locals/plain";
 @import "locals/aspect-ratio";
 @import "locals/not_found_404";
+@import "locals/kimbia";

--- a/app/assets/stylesheets/locals/kimbia.css.scss
+++ b/app/assets/stylesheets/locals/kimbia.css.scss
@@ -3,10 +3,10 @@
         border: none;
         .ui-tabs-nav {
             li.ui-state-active a::before {
-                content: 'Currently Selected: '
+                content: '\2611 ' // Checked checkbox
             }
             li a::before {
-                content: 'Or: '
+                content: '\2610 ' // Empty checkbox
             } 
         }
     }

--- a/app/assets/stylesheets/locals/kimbia.css.scss
+++ b/app/assets/stylesheets/locals/kimbia.css.scss
@@ -1,13 +1,18 @@
 .blacklight-override .k_jquery-ui {
-    .ui-widget-content {
+    .ui-widget {
+        font-family: $font-family;
         border: none;
         .ui-tabs-nav {
-            li.ui-state-active a::before {
-                content: '\2611 ' // Checked checkbox
+            li {
+                a::before { font-size: 130% }
+                a::before { content: '\2610 ' } // Empty checkbox
+                &.ui-state-active a::before { content: '\2611 ' } // Checked checkbox
+                border: 1px solid $light-grey;
             }
-            li a::before {
-                content: '\2610 ' // Empty checkbox
-            } 
+        }
+        .ui-tabs-panel {
+            padding-top: 0;
+            border: 1px solid $light-grey;
         }
     }
 }

--- a/app/assets/stylesheets/locals/kimbia.css.scss
+++ b/app/assets/stylesheets/locals/kimbia.css.scss
@@ -1,0 +1,13 @@
+.blacklight-override .k_jquery-ui {
+    .ui-widget-content {
+        border: none;
+        .ui-tabs-nav {
+            li.ui-state-active a::before {
+                content: 'Currently Selected: '
+            }
+            li a::before {
+                content: 'Or: '
+            } 
+        }
+    }
+}


### PR DESCRIPTION
Towards #602.
@caseyedavis12 : Nick's right, the UI is really unfortunate. Here's what I can do with the CSS:
<img width="450" alt="screen shot 2016-05-03 at 4 12 29 pm" src="https://cloud.githubusercontent.com/assets/730388/14996932/592abbe6-114a-11e6-990a-b0f23b9bb499.png">

Rather than spelling it out, the current commit has:
<img width="300" alt="screen shot 2016-05-03 at 4 21 32 pm" src="https://cloud.githubusercontent.com/assets/730388/14997150/3600608e-114b-11e6-9f5f-52d4cb192789.png">

Thoughts?

I also took off the frame around the whole thing, though I could bring that back. Finally, we should either put a line across the bottom, so the tabs look like tabs... or we should fix the css so they look like regular buttons. I don't care which direction we go.
