### PR TITLE
Removes download button from video player on Chrome

### DIFF
--- a/app/views/catalog/player/_player_left.html.erb
+++ b/app/views/catalog/player/_player_left.html.erb
@@ -13,6 +13,7 @@
   <% elsif !@pbcore.proxy_srcs.empty? && !@pbcore.image? %>
     <%= content_tag(@pbcore.video? ? 'video' : 'audio', 
                   controls: true, id: 'player-media',
+                  controlsList: "nodownload",
                   oncontextmenu: 'return false;',
                   poster: @pbcore.thumbnail_src) do %>
       <% @pbcore.proxy_srcs.each do |src| %>


### PR DESCRIPTION
Fixes #701.